### PR TITLE
Fix hardcoded path & incorrectly bundled DLLs

### DIFF
--- a/CommunityCenterOverhaul/CommunityCenterBundleOverhaul.cs
+++ b/CommunityCenterOverhaul/CommunityCenterBundleOverhaul.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using StardewConfigFramework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -33,7 +34,7 @@ namespace CommunityCenterBundleOverhaul
                 return;
             }
             this.Monitor.Log("Initialisation finished. Bundels are now out of control :D", LogLevel.Info);
-            saves = System.IO.Directory.GetFiles(Constants.ExecutionPath + "\\Mods\\CommunityCenterBundleOverhaul", "StardewConfig-*", System.IO.SearchOption.TopDirectoryOnly);
+            saves = Directory.GetFiles(this.Helper.DirectoryPath, "StardewConfig-*", SearchOption.TopDirectoryOnly);
 
             if (saves.Length < 1)
             {

--- a/CommunityCenterOverhaul/CommunityCenterBundleOverhaul.csproj
+++ b/CommunityCenterOverhaul/CommunityCenterBundleOverhaul.csproj
@@ -14,9 +14,6 @@
     <AssemblyName>CommunityCenterBundleOverhaul</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,6 +38,7 @@
     </Reference>
     <Reference Include="StardewConfigFramework, Version=1.0.6540.35209, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Juice805.StardewConfigFramework.1.0.1\lib\net45\StardewConfigFramework.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
This pull request fixes two issues:
* An error when installed in a different path than `Mods/CommunityCenterBundleOverhaul`. (For example, it's common for players to unzip into `Mods/<zip name>/CommunityCenterBundleOverhaul`.)
* The Stardew Config Framework DLLs were included in the release. (They shouldn't be, since we want to use the version installed by the player.)